### PR TITLE
Fix: Remove jest watchAll from package.json for GitHub Actions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon server.js",
     "prod": "node server.js",
-    "test": "jest --watchAll"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
I removed --watchAll from jest in the package.json scripts block which was causing jest to stay watching on github.